### PR TITLE
Add integration tests for repositories

### DIFF
--- a/internal/repositories/action_type_repo_test.go
+++ b/internal/repositories/action_type_repo_test.go
@@ -1,0 +1,90 @@
+package repositories
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/kevinLL22/stock-tests/internal/db"
+	"github.com/kevinLL22/stock-tests/internal/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActionTypeRepoIntegration(t *testing.T) {
+	databaseURL := "postgresql://root@localhost:26257/defaultdb?sslmode=disable"
+	if databaseURL == "" {
+		t.Fatal("debes exportar DATABASE_URL con la conexión a tu BD de pruebas, e.g. postgresql://root@localhost:26257/testdb?sslmode=disable")
+	}
+
+	if err := db.RunMigrations(databaseURL); err != nil {
+		t.Fatalf("migrations fallaron: %v", err)
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("no se pudo crear pgxpool: %v", err)
+	}
+	defer pool.Close()
+
+	repo := NewActionTypeRepository(pool)
+
+	prev, err := repo.FindAll(ctx)
+	if err != nil {
+		t.Fatalf("FindAll inicial falló: %v", err)
+	}
+	baseCount := len(prev)
+
+	action := models.ActionType{
+		ID:          12345,
+		Code:        "TEST_ACTION",
+		Description: "Test Action",
+	}
+
+	err = repo.Upsert(ctx, action)
+	if err != nil {
+		t.Fatalf("Upsert(insert) falló: %v", err)
+	}
+
+	all, err := repo.FindAll(ctx)
+	if err != nil {
+		t.Fatalf("FindAll falló: %v", err)
+	}
+	if len(all) != baseCount+1 {
+		t.Fatalf("esperaba %d action types, encontré %d", baseCount+1, len(all))
+	}
+
+	created, err := repo.Get(ctx, strconv.FormatInt(action.ID, 10))
+	if err != nil {
+		t.Fatalf("Get(%d) falló: %v", action.ID, err)
+	}
+	assert.Equal(t, action.Code, created.Code)
+	assert.Equal(t, action.Description, created.Description)
+
+	created.Description = "Updated Action"
+	err = repo.Upsert(ctx, created)
+	if err != nil {
+		t.Fatalf("Upsert(update) falló: %v", err)
+	}
+	updated, err := repo.Get(ctx, strconv.FormatInt(action.ID, 10))
+	if err != nil {
+		t.Fatalf("Get después de update falló: %v", err)
+	}
+	assert.Equal(t, "Updated Action", updated.Description)
+
+	err = repo.Delete(ctx, strconv.FormatInt(action.ID, 10))
+	if err != nil {
+		t.Fatalf("Delete(%d) falló: %v", action.ID, err)
+	}
+
+	all2, err := repo.FindAll(ctx)
+	if err != nil {
+		t.Fatalf("FindAll tras delete falló: %v", err)
+	}
+	if len(all2) != baseCount {
+		t.Fatalf("esperaba %d action types tras delete, encontré %d", baseCount, len(all2))
+	}
+	_, err = repo.Get(ctx, strconv.FormatInt(action.ID, 10))
+	assert.Error(t, err, "Get tras delete debería devolver error")
+}

--- a/internal/repositories/brokerage_repo_test.go
+++ b/internal/repositories/brokerage_repo_test.go
@@ -1,0 +1,88 @@
+package repositories
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/kevinLL22/stock-tests/internal/db"
+	"github.com/kevinLL22/stock-tests/internal/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBrokerageRepoIntegration(t *testing.T) {
+	databaseURL := "postgresql://root@localhost:26257/defaultdb?sslmode=disable"
+	if databaseURL == "" {
+		t.Fatal("debes exportar DATABASE_URL con la conexión a tu BD de pruebas, e.g. postgresql://root@localhost:26257/testdb?sslmode=disable")
+	}
+
+	if err := db.RunMigrations(databaseURL); err != nil {
+		t.Fatalf("migrations fallaron: %v", err)
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("no se pudo crear pgxpool: %v", err)
+	}
+	defer pool.Close()
+
+	repo := NewBrokerageRepository(pool)
+
+	prev, err := repo.FindAll(ctx)
+	if err != nil {
+		t.Fatalf("FindAll inicial falló: %v", err)
+	}
+	baseCount := len(prev)
+
+	brokerage := models.Brokerage{
+		ID:   54321,
+		Name: "Test Brokerage",
+	}
+
+	err = repo.Upsert(ctx, brokerage)
+	if err != nil {
+		t.Fatalf("Upsert(insert) falló: %v", err)
+	}
+
+	all, err := repo.FindAll(ctx)
+	if err != nil {
+		t.Fatalf("FindAll falló: %v", err)
+	}
+	if len(all) != baseCount+1 {
+		t.Fatalf("esperaba %d brokerages, encontré %d", baseCount+1, len(all))
+	}
+
+	created, err := repo.Get(ctx, strconv.FormatInt(brokerage.ID, 10))
+	if err != nil {
+		t.Fatalf("Get(%d) falló: %v", brokerage.ID, err)
+	}
+	assert.Equal(t, brokerage.Name, created.Name)
+
+	created.Name = "Updated Brokerage"
+	err = repo.Upsert(ctx, created)
+	if err != nil {
+		t.Fatalf("Upsert(update) falló: %v", err)
+	}
+	updated, err := repo.Get(ctx, strconv.FormatInt(brokerage.ID, 10))
+	if err != nil {
+		t.Fatalf("Get después de update falló: %v", err)
+	}
+	assert.Equal(t, "Updated Brokerage", updated.Name)
+
+	err = repo.Delete(ctx, strconv.FormatInt(brokerage.ID, 10))
+	if err != nil {
+		t.Fatalf("Delete(%d) falló: %v", brokerage.ID, err)
+	}
+
+	all2, err := repo.FindAll(ctx)
+	if err != nil {
+		t.Fatalf("FindAll tras delete falló: %v", err)
+	}
+	if len(all2) != baseCount {
+		t.Fatalf("esperaba %d brokerages tras delete, encontré %d", baseCount, len(all2))
+	}
+	_, err = repo.Get(ctx, strconv.FormatInt(brokerage.ID, 10))
+	assert.Error(t, err, "Get tras delete debería devolver error")
+}

--- a/internal/repositories/rating_type_repo_test.go
+++ b/internal/repositories/rating_type_repo_test.go
@@ -1,0 +1,90 @@
+package repositories
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/kevinLL22/stock-tests/internal/db"
+	"github.com/kevinLL22/stock-tests/internal/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRatingTypeRepoIntegration(t *testing.T) {
+	databaseURL := "postgresql://root@localhost:26257/defaultdb?sslmode=disable"
+	if databaseURL == "" {
+		t.Fatal("debes exportar DATABASE_URL con la conexión a tu BD de pruebas, e.g. postgresql://root@localhost:26257/testdb?sslmode=disable")
+	}
+
+	if err := db.RunMigrations(databaseURL); err != nil {
+		t.Fatalf("migrations fallaron: %v", err)
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("no se pudo crear pgxpool: %v", err)
+	}
+	defer pool.Close()
+
+	repo := NewRatingTypeRepository(pool)
+
+	prev, err := repo.FindAll(ctx)
+	if err != nil {
+		t.Fatalf("FindAll inicial falló: %v", err)
+	}
+	baseCount := len(prev)
+
+	rating := models.RatingType{
+		ID:          67890,
+		Code:        "TEST_RATING",
+		Description: "Test Rating",
+	}
+
+	err = repo.Upsert(ctx, rating)
+	if err != nil {
+		t.Fatalf("Upsert(insert) falló: %v", err)
+	}
+
+	all, err := repo.FindAll(ctx)
+	if err != nil {
+		t.Fatalf("FindAll falló: %v", err)
+	}
+	if len(all) != baseCount+1 {
+		t.Fatalf("esperaba %d rating types, encontré %d", baseCount+1, len(all))
+	}
+
+	created, err := repo.Get(ctx, strconv.FormatInt(rating.ID, 10))
+	if err != nil {
+		t.Fatalf("Get(%d) falló: %v", rating.ID, err)
+	}
+	assert.Equal(t, rating.Code, created.Code)
+	assert.Equal(t, rating.Description, created.Description)
+
+	created.Description = "Updated Rating"
+	err = repo.Upsert(ctx, created)
+	if err != nil {
+		t.Fatalf("Upsert(update) falló: %v", err)
+	}
+	updated, err := repo.Get(ctx, strconv.FormatInt(rating.ID, 10))
+	if err != nil {
+		t.Fatalf("Get después de update falló: %v", err)
+	}
+	assert.Equal(t, "Updated Rating", updated.Description)
+
+	err = repo.Delete(ctx, strconv.FormatInt(rating.ID, 10))
+	if err != nil {
+		t.Fatalf("Delete(%d) falló: %v", rating.ID, err)
+	}
+
+	all2, err := repo.FindAll(ctx)
+	if err != nil {
+		t.Fatalf("FindAll tras delete falló: %v", err)
+	}
+	if len(all2) != baseCount {
+		t.Fatalf("esperaba %d rating types tras delete, encontré %d", baseCount, len(all2))
+	}
+	_, err = repo.Get(ctx, strconv.FormatInt(rating.ID, 10))
+	assert.Error(t, err, "Get tras delete debería devolver error")
+}


### PR DESCRIPTION
## Summary
- add integration tests for `ActionTypeRepository`, `BrokerageRepository` and `RatingTypeRepository`

## Testing
- `go test ./...` *(fails: Forbidden when fetching modules)*

------
https://chatgpt.com/codex/tasks/task_e_684114be995c832891d43db39980329a